### PR TITLE
Add files via upload

### DIFF
--- a/A brief history
+++ b/A brief history
@@ -1,0 +1,25 @@
+A BRIEF HISTORY OF SALA</h1>
+
+(by Hans Henrich Hock with help from Alice Davison; updated December 2024)
+
+The foundation for SALA, the South Asian Languages Analysis Roundtable, was laid during the 1978 Linguistic Institute of the Linguistic Society of America, held at the University of Illinois at Urbana-Champaign. The Linguistic Institute that year featured a “Conference on South Asian Languages and Linguistics”, organized by Hans Henrich Hock and Braj B. Kachru, with support from Yamuna Kachru and Rajeshwari Pandharipande. The Conference attracted many of the top South Asian linguists from both North America and South Asia, and the response was so positive that it was decided to offer similar meetings in the future. There was to be a biennial series of “International Conferences on South Asian Languages and Linguistics” held in India, and an annual series of meetings with more limited, North American scope, and thus SALA was born. Unfortunately, the tradition of international conferences was short-lived and ended after the third Conference, held 1982 in Mysore. As a consequence, there was an increasing tendency to broaden the scope of SALA beyond North America, with meetings in India (1997, 2005), the United Kingdom (1998), Germany (2001), and many other venues since then. The current geographical distribution of SALA hosts reflects the changing picture of South Asian linguistic studies in Europe, North America, and South Asia.
+
+Throughout the years, the goal of SALA conferences has been to provide a meeting ground for linguists working on all South Asian languages, with no restrictions on disciplinary subareas. There have, however, been repeated attempts to encourage the coverage of minority or “Tribal” languages and of language families other than Indo-Aryan and Dravidian. The actual distribution of topics and disciplines at individual conferences, which has tended to favor syntax and semantics, reflects the distribution of submitted abstracts. 
+
+
+From the beginning, SALA Roundtables were organized on an ad-hoc basis, without a formal organization behind them. The advantage has been that, even though the University of Illinois hosted the first three Roundtables, this was not interpreted as establishing a monopoly; and soon other institutions followed suit in hosting the Roundtables. Moreover, there were no membership dues that might impose a financial burden on students and young scholars, especially from South Asia. The disadvantage is that there are no formal membership lists that can be drawn on for calls for papers, and there is no mechanism by which future host institutions can be easily identified. Nevertheless, through informal exchange of mailing lists and through a sufficiently large number of institutions volunteering to host SALA meeting, there has been an amazing and truly impressive succession of yearly meetings – only a few years (1996, 2000, 2007, 2012, and 2013) were without SALAs.
+
+
+The first three meetings, held at the University of Illinois were organized by the same members of the UIUC Linguistics Department as the original Conference on South Asian Languages and Linguistics, with Hans Henrich Hock chairing the planning committee in 1979 and Yamuna Kachru in 1980 and 1981. After 1981, SALA began to be rotate between different universities, organized by local committees with support from national and international committees. The following SALAs have been held so far. (For upcoming meetings see the end of the document.)
+
+2024 – University of Nagaland, India
+
+2023 – University of Venice, Italy
+
+2022 – Tribhuvan University, Kathmandu, Nepal
+
+2019 – INALCO, Paris
+
+2018 – University of Konstanz, Germany
+
+2017 – Adam Mickiewicz University, Poland

--- a/SALA history.html
+++ b/SALA history.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta http-equiv="Content-Style-Type" content="text/css">
+  <title></title>
+  <meta name="Generator" content="Cocoa HTML Writer">
+  <meta name="CocoaVersion" content="2487.7">
+  <style type="text/css">
+    p.p1 {margin: 0.0px 0.0px 0.0px 0.0px; font: 12.0px Helvetica}
+    p.p2 {margin: 0.0px 0.0px 0.0px 0.0px; font: 12.0px Helvetica; min-height: 14.0px}
+  </style>
+</head>
+<body>
+<p class="p1">&lt;!DOCTYPE html&gt;</p>
+<p class="p1">&lt;html&gt;</p>
+<p class="p1">&lt;body&gt;</p>
+<p class="p2"><br></p>
+<p class="p1">&lt;h1&gt;A BRIEF HISTORY OF SALA&lt;/h1&gt;</p>
+<p class="p1">&lt;p&gt;(by Hans Henrich Hock with help from Alice Davison; updated December 2024)</p>
+<p class="p1">The foundation for SALA, the South Asian Languages Analysis Roundtable, was laid during the 1978 Linguistic Institute of the Linguistic Society of America, held at the University of Illinois at Urbana-Champaign. The Linguistic Institute that year featured a “Conference on South Asian Languages and Linguistics”, organized by Hans Henrich Hock and Braj B. Kachru, with support from Yamuna Kachru and Rajeshwari Pandharipande. The Conference attracted many of the top South Asian linguists from both North America and South Asia, and the response was so positive that it was decided to offer similar meetings in the future. There was to be a biennial series of “International Conferences on South Asian Languages and Linguistics” held in India, and an annual series of meetings with more limited, North American scope, and thus SALA was born. Unfortunately, the tradition of international conferences was short-lived and ended after the third Conference, held 1982 in Mysore. As a consequence, there was an increasing tendency to broaden the scope of SALA beyond North America, with meetings in India (1997, 2005), the United Kingdom (1998), Germany (2001), and many other venues since then. The current geographical distribution of SALA hosts reflects the changing picture of South Asian linguistic studies in Europe, North America, and South Asia.</p>
+<p class="p1">Throughout the years, the goal of SALA conferences has been to provide a meeting ground for linguists working on all South Asian languages, with no restrictions on disciplinary subareas. There have, however, been repeated attempts to encourage the coverage of minority or “Tribal” languages and of language families other than Indo-Aryan and Dravidian. The actual distribution of topics and disciplines at individual conferences, which has tended to favor syntax and semantics, reflects the distribution of submitted abstracts. </p>
+<p class="p1"><br>
+From the beginning, SALA Roundtables were organized on an ad-hoc basis, without a formal organization behind them. The advantage has been that, even though the University of Illinois hosted the first three Roundtables, this was not interpreted as establishing a monopoly; and soon other institutions followed suit in hosting the Roundtables. Moreover, there were no membership dues that might impose a financial burden on students and young scholars, especially from South Asia. The disadvantage is that there are no formal membership lists that can be drawn on for calls for papers, and there is no mechanism by which future host institutions can be easily identified. Nevertheless, through informal exchange of mailing lists and through a sufficiently large number of institutions volunteering to host SALA meeting, there has been an amazing and truly impressive succession of yearly meetings – only a few years (1996, 2000, 2007, 2012, and 2013) were without SALAs.</p>
+<p class="p1"><br>
+The first three meetings, held at the University of Illinois were organized by the same members of the UIUC Linguistics Department as the original Conference on South Asian Languages and Linguistics, with Hans Henrich Hock chairing the planning committee in 1979 and Yamuna Kachru in 1980 and 1981. After 1981, SALA began to be rotate between different universities, organized by local committees with support from national and international committees. The following SALAs have been held so far. (For upcoming meetings see the end of the document.)</p>
+<p class="p1">2024 – University of Nagaland, India</p>
+<p class="p1">2023 – University of Venice, Italy</p>
+<p class="p1">2022 – Tribhuvan University, Kathmandu, Nepal</p>
+<p class="p1">2019 – INALCO, Paris</p>
+<p class="p1">2018 – University of Konstanz, Germany</p>
+<p class="p1">2017 – Adam Mickiewicz University, Poland.&lt;/p&gt;</p>
+<p class="p2"><br></p>
+<p class="p1">&lt;/body&gt;</p>
+<p class="p1">&lt;/html&gt;</p>
+</body>
+</html>


### PR DESCRIPTION
A BRIEF HISTORY OF SALA
(by Hans Henrich Hock with help from Alice Davison; updated December 2024)

The foundation for SALA, the South Asian Languages Analysis Roundtable, was laid during the 1978 Linguistic Institute of the Linguistic Society of America, held at the University of Illinois at Urbana-Champaign. The Linguistic Institute that year featured a “Conference on South Asian Languages and Linguistics”, organized by Hans Henrich Hock and Braj B. Kachru, with support from Yamuna Kachru and Rajeshwari Pandharipande. The Conference attracted many of the top South Asian linguists from both North America and South Asia, and the response was so positive that it was decided to offer similar meetings in the future. There was to be a biennial series of “International Conferences on South Asian Languages and Linguistics” held in India, and an annual series of meetings with more limited, North American scope, and thus SALA was born. Unfortunately, the tradition of international conferences was short-lived and ended after the third Conference, held 1982 in Mysore. As a consequence, there was an increasing tendency to broaden the scope of SALA beyond North America, with meetings in India (1997, 2005), the United Kingdom (1998), Germany (2001), and many other venues since then. The current geographical distribution of SALA hosts reflects the changing picture of South Asian linguistic studies in Europe, North America, and South Asia.

Throughout the years, the goal of SALA conferences has been to provide a meeting ground for linguists working on all South Asian languages, with no restrictions on disciplinary subareas. There have, however, been repeated attempts to encourage the coverage of minority or “Tribal” languages and of language families other than Indo-Aryan and Dravidian. The actual distribution of topics and disciplines at individual conferences, which has tended to favor syntax and semantics, reflects the distribution of submitted abstracts. 


From the beginning, SALA Roundtables were organized on an ad-hoc basis, without a formal organization behind them. The advantage has been that, even though the University of Illinois hosted the first three Roundtables, this was not interpreted as establishing a monopoly; and soon other institutions followed suit in hosting the Roundtables. Moreover, there were no membership dues that might impose a financial burden on students and young scholars, especially from South Asia. The disadvantage is that there are no formal membership lists that can be drawn on for calls for papers, and there is no mechanism by which future host institutions can be easily identified. Nevertheless, through informal exchange of mailing lists and through a sufficiently large number of institutions volunteering to host SALA meeting, there has been an amazing and truly impressive succession of yearly meetings – only a few years (1996, 2000, 2007, 2012, and 2013) were without SALAs.


The first three meetings, held at the University of Illinois were organized by the same members of the UIUC Linguistics Department as the original Conference on South Asian Languages and Linguistics, with Hans Henrich Hock chairing the planning committee in 1979 and Yamuna Kachru in 1980 and 1981. After 1981, SALA began to be rotate between different universities, organized by local committees with support from national and international committees. The following SALAs have been held so far. (For upcoming meetings see the end of the document.)

2024 – University of Nagaland, India

2023 – University of Venice, Italy

2022 – Tribhuvan University, Kathmandu, Nepal

2019 – INALCO, Paris

2018 – University of Konstanz, Germany

2017 – Adam Mickiewicz University, Poland